### PR TITLE
ID'd magic tiers along with a few other additions

### DIFF
--- a/BH-classic.cfg
+++ b/BH-classic.cfg
@@ -1,4 +1,4 @@
-// Slash Diablo CLASSIC Maphack Configuration, v2.7.1
+// Slash Diablo CLASSIC Maphack Configuration, v2.7.2
 // Authors: BeLikeLeBron, Lewds, Fap, Davichi, M81, Dax, Labarr
 // Requires BH>=1.9.9 (planqi branch)
 // Note: 1.9.9-b10 no longer supported. Must have the full Planqi 1.9.9 BH.dll release OR Danny's beta bh 1.9.9

--- a/BH.cfg
+++ b/BH.cfg
@@ -366,7 +366,7 @@ ItemDisplay[SCEPTER MAG CLSK3>1]: %SAGE%T5%MAP% %GREEN%*****%PURPLE%%NAME%%GREEN
 ItemDisplay[!ID MAG cm2 CLVL<60 FILTLVL<2]: %WHITE%+%BLUE%T6%border-97%%dot-00% %NAME%%notify-3%%TIER-6%
 
 // Sharkskin or Vampirefang belts for crafting caster belts up to level 80
-ItemDisplay[(zvb OR uvc) !ETH MAG !ID CLVL<80 FILTLVL<2]: %GREEN%+%GRAY%T6T6%border-97%%dot-00% %BLUE%%NAME%%notify-3%%TIER-6%
+ItemDisplay[(zvb OR uvc) !ETH MAG !ID CLVL<80 FILTLVL<2]: %GREEN%+%GRAY%T6%border-97%%dot-00% %BLUE%%NAME%%notify-3%%TIER-6%
 
 //any demonhide sash or sharkskin belt for ladder reset
 ItemDisplay[NMAG (zlb OR zvb) CLVL<41 FILTLVL<2]: %GRAY%T6%MAP% %WHITE%%NAME%%TIER-6%
@@ -543,6 +543,8 @@ ItemDisplay[RW]: %NAME%%GOLD%%CONTINUE%
 ItemDisplay[(NORM OR EXC OR ELT OR rin OR amu) NMAG !RW]: %NAME%%WHITE%%CONTINUE%
 ItemDisplay[CRAFT]: %NAME%%ORANGE%%CONTINUE% // need 1.9.8
 
+// Notifications for dropped runewords
+ItemDisplay[RW]: %NAME%%GOLD%%MAP%
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -1690,35 +1692,36 @@ ItemDisplay[FILTLVL<3 NMAG !RW ulc]: %NAME% // Spiderweb Sash (Imbue)
 // TIER 3
 // ------
 
-// grand charms with potential 45 life (only from Hell Baal, Diablo, and Nihlathak) (add // on the line below to remove)
-ItemDisplay[!ID MAG cm3 ILVL>90]: %RED%+T3%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
-
 // grand charms with potential 45 life marked with a red + for rerolling (identified) (add // on the line below to remove)
-ItemDisplay[ID MAG cm3 ILVL>90]: %RED%+T3%BLUE%%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
+ItemDisplay[MAG cm3 ILVL>90]: %NAME% %GREEN%+%CONTINUE%
+
+// grand charms with potential 45 life (only from Hell Baal, Diablo, and Nihlathak) (add // on the line below to remove)
+ItemDisplay[!ID MAG cm3 ILVL>90]: %RED%T3%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
+
 
 // TIER 4
 // ------
 
 // Circlet Variants (many good things)
-ItemDisplay[CIRC !ETH MAG !ID]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%notify-3%%TIER-4%
+ItemDisplay[CIRC !ETH MAG !ID]: %GOLD%T4%BLUE%%MAP% %NAME%%notify-3%%TIER-4%
 
 //Old line for jewels small and grand charms (remove // on the line below AND add // on the gc/jewels/sc lines below to use)
-//ItemDisplay[!ID MAG (cm1 OR cm3 OR jew)]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%notify-3%%TIER-4%
+//ItemDisplay[!ID MAG (cm1 OR cm3 OR jew)]: %GOLD%T4%BLUE%%MAP% %NAME%%notify-3%%TIER-4%
 
 // grand charms
-ItemDisplay[!ID MAG cm3]: %GOLD%+%GOLD%T4%border-97%%dot-1f% %NAME%%notify-3%%TIER-4%
+ItemDisplay[!ID MAG cm3]: %GOLD%T4%border-97%%dot-1f% %NAME%%notify-3%%TIER-4%
 
 // Small charms
-ItemDisplay[!ID MAG cm1]: %GOLD%+%GOLD%T4%border-97%%dot-84%%px-97% %NAME%%notify-3%%TIER-4% 
+ItemDisplay[!ID MAG cm1]: %GOLD%T4%border-97%%dot-84%%px-97% %NAME%%notify-3%%TIER-4% 
 
 // Large charms with notifications on tier 4 (remove // on the line below to use)
 //ItemDisplay[!ID MAG cm2]: %WHITE%+%GRAY%T6%border-97%%dot-00% %NAME%%notify-3%%TIER-4%
 
 //jewels
-ItemDisplay[!ID MAG jew]: %GOLD%+%GOLD%T4%Map-97%%dot-97%%px-00% %NAME%%notify-3%%TIER-4%
+ItemDisplay[!ID MAG jew]: %GOLD%T4%Map-97%%dot-97%%px-00% %NAME%%notify-3%%TIER-4%
 
 // Monarchs (for JMoD)
-ItemDisplay[uit !ETH MAG !ID]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%TIER-4%
+ItemDisplay[uit !ETH MAG !ID]: %GOLD%T4%BLUE%%MAP% %NAME%%TIER-4%
 
 
 // TIER 5
@@ -1726,22 +1729,22 @@ ItemDisplay[uit !ETH MAG !ID]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%TIER-4%
 // %border-97%%dot-00%
 
 // Eth circlet variants
-ItemDisplay[CIRC ETH MAG !ID FILTLVL<2]: %GREEN%+%GRAY%T6%MAP% %NAME%%notify-3%%TIER-6%
+ItemDisplay[CIRC ETH MAG !ID FILTLVL<2]: %WHITE%+%GRAY%T6%MAP% %NAME%%notify-3%%TIER-6%
 
 // Magic Amulets
-ItemDisplay[MAG amu CRAFTALVL>89]: %GREEN%+ %NAME%%CONTINUE%
+ItemDisplay[MAG amu CRAFTALVL>89]: %NAME% %GREEN%+%CONTINUE%
 
 // Magic Amulets ilvl 88+ ping only if filter 1 with tier 5 (useful to save for crafting or if looking for +3 warcry/fire Amulets)
-ItemDisplay[MAG amu !ID ILVL>87 FILTLVL=1 CRAFTALVL<90]: %WHITE%+%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-5%
-ItemDisplay[MAG amu !ID ILVL>87 FILTLVL=1 CRAFTALVL>89]: %border-97%%MAP-00%%dot-97%%NAME%%notify-3%%TIER-5% //no double white/green dot for chars high enough to craft
+ItemDisplay[MAG amu !ID ILVL>87 FILTLVL=1 CRAFTALVL<90]: %SAGE%T5%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-5%
+ItemDisplay[MAG amu !ID ILVL>87 FILTLVL=1 CRAFTALVL>89]: %SAGE%T5%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-5% //no double white/green dot for chars high enough to craft
 
 // Magic Amulets (all) ping if filter level 1 tier 6
-ItemDisplay[MAG amu !ID FILTLVL=1 CRAFTALVL<90]: %WHITE%+%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-6%
-ItemDisplay[MAG amu !ID FILTLVL=1 CRAFTALVL>89]: %border-97%%MAP-00%%dot-97%%NAME%%notify-3%%TIER-6% //no double white/green dot for chars high enough to craft
+ItemDisplay[MAG amu !ID FILTLVL=1 CRAFTALVL<90]: %GRAY%T6%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-6%
+ItemDisplay[MAG amu !ID FILTLVL=1 CRAFTALVL>89]: %GRAY%T6%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-6% //no double white/green dot for chars high enough to craft
 
 // Magic Amulets (all) Ping if filter level 0 tier 5
-ItemDisplay[MAG amu !ID FILTLVL=0 CRAFTALVL<90]: %WHITE%+%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-5%
-ItemDisplay[MAG amu !ID FILTLVL=0 CRAFTALVL>89]: %border-97%%MAP-00%%dot-97%%NAME%%notify-3%%TIER-5% //no double white/green dot for chars high enough to craft
+ItemDisplay[MAG amu !ID FILTLVL=0 CRAFTALVL<90]: %SAGE%T5%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-5%
+ItemDisplay[MAG amu !ID FILTLVL=0 CRAFTALVL>89]: %SAGE%T5%border-97%%MAP-00%%dot-97% %NAME%%notify-3%%TIER-5% //no double white/green dot for chars high enough to craft
 
 // Magic Amulets Whitelist
 ItemDisplay[MAG amu !ID]: %NAME%
@@ -1797,6 +1800,547 @@ ItemDisplay[FILTLVL<3 MAG umc !ID]: %NAME% // Mithril Coil (Blood Belt)
 // #endregion - Magic Items
 
 //
+//IDENTIFIED MAGIC ITEMS
+// ===========
+// #region - Identified Magic Tiers
+
+//Ordered by type and sub-ordered by tiers.
+//Some Shoppable magic weapons/gloves/armors are in the shopping section (such as claws/javazon gloves)
+
+//IDENTIFIED MAGIC HELMS AND CIRCLETS
+
+// 6bo Barb helms
+ItemDisplay[MAG ID BAR TABSK34=3 SK149=3]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+
+// 6 tornado druid pelt
+ItemDisplay[MAG ID DRU TABSK42=3 SK245=3]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+
+// 3 os circs
+// 3os 30frw circ
+ItemDisplay[MAG ID CIRC SOCK=3 FRW=30]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 3os 20fcr circ
+ItemDisplay[MAG ID CIRC SOCK=3 FCR=20]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 3os 25+mf circ
+ItemDisplay[MAG ID CIRC SOCK=3 MFIND>24]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 3os >80 life circ
+ItemDisplay[MAG ID CIRC SOCK=3 LIFE>80]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3os >20 damage reduction circ
+ItemDisplay[MAG ID CIRC SOCK=3 STAT34>19]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 3os 30 str/dex circ
+ItemDisplay[MAG ID CIRC SOCK=3 (STR=30 or DEX=30)]: %GOLD%T4%MAP% %NAME%%TIER-4%
+
+// 3 tab skill circs 20 fcr (30 frw bow) 2 os Circ
+// 3 pnb 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK17=3 FCR=20 SOCK=2]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 3 bow 30 frw 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK0=3 FRW=30 SOCK=2]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 3 fire 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK8=3 FCR=20 SOCK=2]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 3 light 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK9=3 FCR=20 SOCK=2]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 3 ele 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK42=3 FCR=20 SOCK=2]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 3 cold 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK10=3 FCR=20 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 pcomb 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK24=3 FCR=20 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 trap 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC TABSK48=3 FCR=20 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+
+// 3 tab skill 20 fcr (30 frw bow) circs no socket
+// 3 pnb 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK17=3 FCR=20]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 bow 30 frw circ
+ItemDisplay[MAG ID CIRC TABSK0=3 FRW=30]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 fire 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK8=3 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 light 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK9=3 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 cold 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK10=3 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 pcomb 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK24=3 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 ele 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK42=3 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+// 3 trap 20 fcr Circ
+ItemDisplay[MAG ID CIRC TABSK48=3 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% {%WHITE%Socket Quest for possible 2 sockets}
+
+// 2 class skill 20 fcr (30 frw zon) 2 os Circ
+// 2 necro 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC CLSK2=2 FCR=20 SOCK=2]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 2 pal 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC CLSK3=2 FCR=20 SOCK=2]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 2 zon 30 frw 2 os Circ
+ItemDisplay[MAG ID CIRC CLSK0=2 FRW=30 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 2 sorc 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC CLSK1=2 FCR=20 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 2 druid 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC CLSK5=2 FCR=20 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 2 sin 20 fcr 2 os Circ
+ItemDisplay[MAG ID CIRC CLSK6=2 FCR=20 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+
+// 2 class skill 20 fcr Circ (30 frw zon) no socket
+// 2 necro 20 fcr Circ
+ItemDisplay[MAG ID CIRC CLSK2=2 FCR=20]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%  {%WHITE%Socket Quest for possible 2 sockets}
+// 2 zon 30 frw Circ
+ItemDisplay[MAG ID CIRC CLSK0=2 FRW=30]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%  {%WHITE%Socket Quest for possible 2 sockets}
+// 2 sorc 20 fcr Circ
+ItemDisplay[MAG ID CIRC CLSK1=2 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%  {%WHITE%Socket Quest for possible 2 sockets}
+// 2 pal 20 fcr Circ
+ItemDisplay[MAG ID CIRC CLSK3=2 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%  {%WHITE%Socket Quest for possible 2 sockets}
+// 2 druid 20 fcr Circ
+ItemDisplay[MAG ID CIRC CLSK5=2 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%  {%WHITE%Socket Quest for possible 2 sockets}
+// 2 sin 20 fcr Circ
+ItemDisplay[MAG ID CIRC CLSK6=2 FCR=20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%  {%WHITE%Socket Quest for possible 2 sockets}
+
+
+//IDENTIFIED MAGIC ARMORS
+// 4 os >80 life
+ItemDisplay[MAG ID ARMOR SOCK=4 LIFE>80]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 4 os 24 fhr
+ItemDisplay[MAG ID ARMOR SOCK=4 FHR=24]: %SAGE%T5%MAP% %NAME%%TIER-5%
+
+
+//IDENTIFIED MAGIC SHIELDS
+// Jewelers Monarch of deflecting / blocking / equilibrium / life
+ItemDisplay[MAG ID uit SOCK=4 FBR=30]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+ItemDisplay[MAG ID uit SOCK=4 FBR=15]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[MAG ID uit SOCK=4 FHR=17]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[MAG ID uit SOCK=4 LIFE>50]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+
+
+//IDENTIFIED MAGIC WEAPONS
+// 6 enchant orbs
+ItemDisplay[MAG ID SORC TABSK8=3 SK52=3]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8% {%WHITE%Socket Quest for possible 2 sockets}
+// 6/40 javelins
+ItemDisplay[MAG ID (am5 OR ama OR amf) IAS=40 TABSK2=6]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 5 enchant orbs (all combinations)
+ItemDisplay[MAG ID SORC SK52=3 CLSK1=2]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2% {%WHITE%Socket Quest for possible 2 sockets}
+ItemDisplay[MAG ID SORC SK52=2 TABSK8=3]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2% {%WHITE%Socket Quest for possible 2 sockets}
+ItemDisplay[MAG ID SORC SK52=3 TABSK8=2]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2% {%WHITE%Socket Quest for possible 2 sockets}
+// 4-5/40 javelins
+ItemDisplay[MAG ID (am5 OR ama OR amf) IAS=40 TABSK2>3 TABSK2<6]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 4-5/40 javelins
+ItemDisplay[MAG ID (am5 OR ama OR amf) IAS=40 TABSK2>2 CLSK0=2]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+
+//IDENTIFIED MAGIC RINGS AND AMULETS
+// 40 mf ring
+ItemDisplay[MAG ID rin MFIND=40]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 31-40 mf ring
+ItemDisplay[MAG ID rin MFIND>30]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 10 fcr 15 all resist rings
+ItemDisplay[MAG ID rin FCR=10 PRES+FRES+CRES+LRES=60]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 10 fcr 15 mf ring
+ItemDisplay[MAG ID rin FCR=10 MFIND=15]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 10 fcr 10-14 resist rings
+ItemDisplay[MAG ID rin FCR=10 PRES+FRES+CRES+LRES>39 PRES+FRES+CRES+LRES<60]: %SAGE%T5%MAP% %NAME%%TIER-5%
+
+// 50 mf Amulet
+ItemDisplay[MAG ID amu MFIND=50]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 41-50 mf Amulet
+ItemDisplay[MAG ID amu MFIND>40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 25 Damage reduction Amulet
+ItemDisplay[MAG ID amu STAT34=25]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 20+ Damage reduction Amulet
+ItemDisplay[MAG ID amu STAT34>19]: %GOLD%T4%MAP% %NAME%%TIER-4%
+
+// 2 class skill 10 fcr Amulets
+// 2 necro 10 fcr
+ItemDisplay[MAG ID amu CLSK2=2 FCR=10]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 2 pal 10 fcr
+ItemDisplay[MAG ID amu CLSK3=2 FCR=10]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 2 sorc 10 fcr
+ItemDisplay[MAG ID amu CLSK1=2 FCR=10]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 2 druid 10 fcr
+ItemDisplay[MAG ID amu CLSK5=2 FCR=10]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 2 sin 10 fcr
+ItemDisplay[MAG ID amu CLSK6=2 FCR=10]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+// 3 tab skill 10 fcr Amulets
+// 3 P&B 10 FCR amulet
+ItemDisplay[MAG ID amu TABSK17=3 FCR=10]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 3 lightning 10 fcr amulet
+ItemDisplay[MAG ID amu TABSK9=3 FCR=10]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 3 fire 10 fcr amulet 
+ItemDisplay[MAG ID amu TABSK8=3 FCR=10]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 cold 10 fcr amulet
+ItemDisplay[MAG ID amu TABSK10=3 FCR=10]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 elemental 10 fcr amulet
+ItemDisplay[MAG ID amu TABSK42=3 FCR=10]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 traps 10 fcr amulet
+ItemDisplay[MAG ID amu TABSK48=3 FCR=10]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 warcry 10 fcr amulet
+ItemDisplay[MAG ID amu TABSK34=3 FCR=10]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 paladin combat 10 fcr amulet
+ItemDisplay[MAG ID amu TABSK24=3 FCR=10]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+// 3 tab skill plain Amulets
+// 3 fire amulet 
+ItemDisplay[MAG ID amu TABSK8=3]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 warcry amulet
+ItemDisplay[MAG ID amu TABSK34=3]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 cold amulet
+ItemDisplay[MAG ID amu TABSK10=3]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 3 traps amulet
+ItemDisplay[MAG ID amu TABSK48=3]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 3 P&B amulet
+ItemDisplay[MAG ID amu TABSK17=3]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 3 lightning amulet
+ItemDisplay[MAG ID amu TABSK9=3]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 3 elemental amulet
+ItemDisplay[MAG ID amu TABSK42=3]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 3 paladin combat amulet
+ItemDisplay[MAG ID amu TABSK24=3]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+
+//IDENTIFIED MAGIC JEWELS
+// 15ias 40ED jewel
+ItemDisplay[MAG ID jew IAS=15 ED=40]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 15ias 30-39ED jewel
+ItemDisplay[MAG ID jew IAS=15 ED>29 ED<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 15ias 30 fire resist jewel
+ItemDisplay[MAG ID jew IAS=15 FRES=30]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 15ias 15 all resist jewel
+ItemDisplay[MAG ID jew IAS=15 FRES+CRES+LRES+PRES=60]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 25+ Max damage jewel
+ItemDisplay[MAG ID jew MAXDMG>24]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15ias jewel 10+ Max damage jewel
+ItemDisplay[MAG ID jew IAS=15 MAXDMG>9]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15ias jewel 1+ Mana per kill
+ItemDisplay[MAG ID jew IAS=15 STAT138>0]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15ias 10+ fire resist jewel
+ItemDisplay[MAG ID jew IAS=15 FRES>9]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15ias 11+ all resist jewel
+ItemDisplay[MAG ID jew IAS=15 FRES+CRES+LRES+PRES>40]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 7fhr 15 all resist jewel
+ItemDisplay[MAG ID jew FHR=7 FRES+CRES+LRES+PRES=60]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15ias 15+ED jewel
+ItemDisplay[MAG ID jew IAS=15 ED>14 ED<30]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 15ias 5+ fire resist jewel
+ItemDisplay[MAG ID jew IAS=15 FRES>4]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 15ias 15+ light resist jewel
+ItemDisplay[MAG ID jew IAS=15 LRES>14]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 15 all resist jewel
+ItemDisplay[MAG ID jew FRES+CRES+LRES+PRES=60]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 25+ fire resist jewel with str/life/dex
+ItemDisplay[MAG ID jew FRES>24 STR+DEX+LIFE>1]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 7fhr 10+ all resist jewel
+ItemDisplay[MAG ID jew FHR=7 FRES+CRES+LRES+PRES>39]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 20+ED jewel with str/life/dex
+ItemDisplay[MAG ID jew ED>19 STR+DEX+LIFE>1]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 40ED jewel
+ItemDisplay[MAG ID jew ED=40]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 10+ all resist jewel
+ItemDisplay[MAG ID jew FRES+CRES+LRES+PRES>39]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 15ias jewel
+ItemDisplay[MAG ID jew IAS=15]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 20+ED jewel
+ItemDisplay[MAG ID jew ED>19 ED<40]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+
+//IDENTIFIED GRAND CHARMS
+//Amazon Skillers
+// Javelin Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK2=1 LIFE>39]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Javelin Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK2=1 LIFE>19 LIFE<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Javelin Skills + frw grand charm
+ItemDisplay[MAG ID cm3 TABSK2=1 FRW=7]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Javelin Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK2=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Bow Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK0=1 LIFE>39]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Bow Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK0=1 LIFE>19 LIFE<40]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Bow Skills + frw grand charm 
+ItemDisplay[MAG ID cm3 TABSK0=1 FRW=7]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// Bow Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK0=1]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// Passive Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK1=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Assassin Skillers
+// Trap Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK48=1 LIFE>39]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Trap Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK48=1 LIFE>19 LIFE<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Shadow Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK49=1 LIFE>39]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Trap Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK48=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Shadow Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK49=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Martial Arts Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK50=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Barbarian Skillers
+// Warcry Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK34=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Barbarian Combat Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK32=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Masteries Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK33=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Druid Skillers
+// Elemental Skills 40-45 life grand charm 
+ItemDisplay[MAG ID cm3 TABSK42=1 LIFE>39]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Elemental Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK42=1 LIFE>19 LIFE<40]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Elemental Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK42=1]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// Shapeshifting Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK41=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Druid Summoning Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK40=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Necromancer Skillers
+// Poison & Bone Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK17=1 LIFE>39]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// Poison & Bone Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK17=1 LIFE>19 LIFE<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Poison & Bone Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK17=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Necro Summoning skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK18=1 LIFE>39]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Necro Summoning skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK18=1 LIFE>19 LIFE<40]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Necro Summoning skills grand charm
+ItemDisplay[MAG ID cm3 TABSK18=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Curses skills grand charm
+ItemDisplay[MAG ID cm3 TABSK16=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Paladin Skillers
+// Paladin Comabat Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK24=1 LIFE>39]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// Paladin Comabat Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK24=1 LIFE>19 LIFE<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Paladin Comabat Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK24=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Offensive Aura Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK25=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Defensive Aura Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK26=1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Sorceress Skillers
+// Cold Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK10=1 LIFE>39]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// Fire skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK8=1 LIFE>39]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// Lightning Skills 40-45 life grand charm
+ItemDisplay[MAG ID cm3 TABSK9=1 LIFE>39]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// Lightning Skills 30-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK9=1 LIFE>29 LIFE<40]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// Cold Skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK10=1 LIFE>19 LIFE<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Fire skills 20-39 life grand charm
+ItemDisplay[MAG ID cm3 TABSK8=1 LIFE>19 LIFE<40]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Lightning Skills 20-29 life grand charm
+ItemDisplay[MAG ID cm3 TABSK9=1 LIFE>19 LIFE<30]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// Cold Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK10=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Fire skills grand charm
+ItemDisplay[MAG ID cm3 TABSK8=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// Lightning Skills grand charm
+ItemDisplay[MAG ID cm3 TABSK9=1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+
+//Other Grand Charms
+// 10 max + 40-45 life grand charm
+ItemDisplay[MAG ID cm3 MAXDMG=10 LIFE>39]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 13+ max grand charm
+ItemDisplay[MAG ID cm3 MAXDMG>13]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+//10 max + 35+ life grand charm
+ItemDisplay[MAG ID cm3 MAXDMG=10 LIFE>34]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+//10 max + 21+ life grand charm
+ItemDisplay[MAG ID cm3 MAXDMG=10 LIFE>20]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+//100+ Attack Rating 30+ life grand charm
+ItemDisplay[MAG ID cm3 AR>99 LIFE>30]: %GOLD%T4%MAP% %NAME%%TIER-4%
+//7-9 max + 21+ life grand charm
+ItemDisplay[MAG ID cm3 MAXDMG>6 LIFE>20]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 10+ max grand charm
+ItemDisplay[MAG ID cm3 MAXDMG>9 MAXDMG<13]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 14+ all resist grand charm
+ItemDisplay[MAG ID cm3 FRES+CRES+LRES+PRES>55]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 30+ gold find grand charm with 15+ resist
+ItemDisplay[MAG ID cm3 GFIND>29 CRES+LRES+FRES>14]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 40 gold find grand charm
+ItemDisplay[MAG ID cm3 GFIND=40]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 38+ gold find grand charm
+ItemDisplay[MAG ID cm3 GFIND>38]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 30+ Life 30+ mana grand charm
+ItemDisplay[MAG ID cm3 LIFE>29 MANA>29]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 9 max grand charm
+ItemDisplay[MAG ID cm3 MAXDMG>9]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 25+ fire/light resist grand charm
+ItemDisplay[MAG ID cm3 FRES+LRES>24]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 12+ all resist grand charm
+ItemDisplay[MAG ID cm3 FRES+CRES+LRES+PRES>47]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//IDENTIFIED LARGE CHARMS
+// 8 max large charm
+ItemDisplay[MAG ID cm2 MAXDMG=8]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 6 max 30+ life large charm
+ItemDisplay[MAG ID cm2 MAXDMG=6 LIFE>29]: %GOLD%T4%MAP% %NAME%%TIER-4%
+//6 max 8 fhr large charm
+ItemDisplay[MAG ID cm2 MAXDMG=6 FHR=8]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 30+ gold find large charm with 15+ resist
+ItemDisplay[MAG ID cm2 GFIND>18 CRES+LRES+FRES>10]: %SAGE%T5%MAP% %NAME%%TIER-5%
+
+//IDENTIFIED SMALL CHARMS
+//Life Small Charms
+// 20 life 17 mana Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 MANA=17]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 20 life + 5 all Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 PRES+FRES+CRES+LRES=20]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 20 life 3 max Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 MAXDMG=3]: %ORANGE%T1%MAP%%LINE-68% %NAME%%notify-8%
+// 20 life + 11 fire resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 FRES=11]: %RED%* %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 15-19 life + 3 max Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 LIFE<20 MAXDMG=3]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 20 life + 11 light resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 LRES=11]: %YELLOW%* %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 15-20 life 11-17 mana Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 LIFE<21 MANA>10 MANA<18]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15-20 life + 3-5 all Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 PRES+FRES+CRES+LRES>11]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15-20 life + 6-11 fire resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 FRES>5]: %RED%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15-20 life + 6-11 light resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 LRES>5]: %YELLOW%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 20 life + 11 cold resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 CRES=11]: %BLUE%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 20 life + 11 poison resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20 PRES=11]: %DARK_GREEN%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 15-20 life + 6-11 cold resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 CRES>5]: %BLUE%* %GOLD%T4%MAP% %NAME%%TIER-4%
+// 15-20 life + 6-11 poison resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14 PRES>5]: %DARK_GREEN%* %GOLD%T4%MAP% %NAME%%TIER-4%
+// 10+ life + 7-11 Fire resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>9 FRES>6]: %RED%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 10+ life + 7-11 light resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>9 LRES>6]: %YELLOW%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 10+ life + 7-11 cold resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>9 CRES>6]: %BLUE%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 10+ life + 7-11 poison resist Small Charm
+ItemDisplay[MAG ID cm1 LIFE>9 PRES>6]: %DARK_GREEN%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 20 life Small Charm
+ItemDisplay[MAG ID cm1 LIFE=20]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 13+ life + 2+ max damage Small Charm
+ItemDisplay[MAG ID cm1 LIFE>12 MAXDMG>1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 15+ life Small Charm
+ItemDisplay[MAG ID cm1 LIFE>14]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Faster Hit Recovery Small Charms
+// fhr + 5 all Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 PRES+FRES+CRES+LRES=20]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// fhr + 11 fire resist Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 FRES=11]: %RED%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// fhr + 11 cold resist Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 CRES=11]: %BLUE%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// fhr + 11 light resist Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 LRES=11]: %YELLOW%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// fhr + 11 poison resist Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 PRES=11]: %DARK_GREEN%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// fhr + 17 mana Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 MANA=17]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// fhr + 3 max Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 MAXDMG=3]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// fhr + 2+ max damage Small Charm
+ItemDisplay[MAG ID cm1 FHR=5 MAXDMG>2]: %SAGE%T5%MAP% %NAME%%TIER-5%
+
+//Magic Find Small Charms
+// 7mf + 3 max damage Small Charm
+ItemDisplay[MAG ID cm1 MFIND=7 MAXDMG=3]: %PURPLE%T2%MAP%%LINE-9B% %NAME%%notify-0b%%TIER-2%
+// 7mf + 11 fire resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND=7 FRES=11]: %RED%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 7mf + 11 light resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND=7 LRES=11]: %YELLOW%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 7mf + 11 cold resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND=7 CRES=11]: %BLUE%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 7mf + 11 poison resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND=7 PRES=11]: %DARK_GREEN%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 6+ mf + 10+ Fire resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND>5 FRES>9]: %RED%* %GOLD%T4%MAP% %NAME%%TIER-4%
+// 6+ mf + 10+ Light resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND>5 LRES>9]: %YELLOW%* %GOLD%T4%MAP% %NAME%%TIER-4%
+// 6+ mf + 10+ Cold resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND>5 CRES>9]: %BLUE%* %GOLD%T4%MAP% %NAME%%TIER-4%
+// 6+ mf + 10+ Poison resist Small Charm
+ItemDisplay[MAG ID cm1 MFIND>5 PRES>9]: %DARK_GREEN%* %GOLD%T4%MAP% %NAME%%TIER-4%
+// 7mf Small Charm
+ItemDisplay[MAG ID cm1 MFIND=7]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 5+mf + 2+ max damage Small Charm
+ItemDisplay[MAG ID cm1 MFIND>4 MAXDMG>1]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 6mf Small Charm
+ItemDisplay[MAG ID cm1 MFIND=6]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 3+mf + 2+ max damage Small Charm
+ItemDisplay[MAG ID cm1 MFIND>3 MAXDMG>1]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Faster Run/walk Small Charms
+// 3 frw + 3 max Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 MAXDMG=3]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 frw + 11 fire resist Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 FRES=11]: %RED%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 frw + 11 light resist Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 LRES=11]: %YELLOW%* %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+// 3 frw + 9+ fire resist Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 FRES>8]: %RED%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 3 frw + 9+ light resist Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 LRES>8]: %YELLOW%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 3 frw + 11 cold resist Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 CRES=11]: %BLUE%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 3 frw + 11 poison resist Small Charm
+ItemDisplay[MAG ID cm1 FRW=3 PRES=11]: %DARK_GREEN%* %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Resist Small Charms
+// 5 all resist Small Charm Small Charm
+ItemDisplay[MAG ID cm1 PRES+FRES+CRES+LRES=20]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// 11 fire Small Charm
+ItemDisplay[MAG ID cm1 FRES=11]: %RED%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 11 cold Small Charm
+ItemDisplay[MAG ID cm1 CRES=11]: %BLUE%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 11 light Small Charm
+ItemDisplay[MAG ID cm1 LRES=11]: %YELLOW%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 11 poison Small Charm
+ItemDisplay[MAG ID cm1 PRES=11]: %DARK_GREEN%* %SAGE%T5%MAP% %NAME%%TIER-5%
+// 3+ all resist Small Charm
+ItemDisplay[MAG ID cm1 PRES+FRES+CRES+LRES>11]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 9+ fire Small Charm
+ItemDisplay[MAG ID cm1 FRES>8]: %RED%* %GRAY%T6%MAP% %NAME%%TIER-6%
+// 9+ cold Small Charm
+ItemDisplay[MAG ID cm1 CRES>8]: %BLUE%* %GRAY%T6%MAP% %NAME%%TIER-6%
+// 9+ light Small Charm
+ItemDisplay[MAG ID cm1 LRES>8]: %YELLOW%* %GRAY%T6%MAP% %NAME%%TIER-6%
+// 9+ poison Small Charm
+ItemDisplay[MAG ID cm1 PRES>8]: %DARK_GREEN%* %GRAY%T6%MAP% %NAME%%TIER-6%
+
+//Other Small Charms
+// light damage Small Charm
+ItemDisplay[MAG ID cm1 STAT51>72]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// light damage Small Charm
+ItemDisplay[MAG ID cm1 STAT51>43]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// cold damage Small Charm
+ItemDisplay[MAG ID cm1 STAT55>14]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// fire damage Small Charm
+ItemDisplay[MAG ID cm1 STAT49>19]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// poison damage Small Charm
+ItemDisplay[MAG ID cm1 STAT58>300]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 3 max Small Charm
+ItemDisplay[MAG ID cm1 MAXDMG=3]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 17 mana Small Charm
+ItemDisplay[MAG ID cm1 MANA=17]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 10 gold find Small Charm
+ItemDisplay[MAG ID cm1 GFIND=10]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// 7+ gold find with 7+ resist Small Charm
+ItemDisplay[MAG ID cm1 GFIND>6 FRES+CRES+LRES>6]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// fhr Small Charm
+ItemDisplay[MAG ID cm1 FHR=5]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// 36 attack rating Small Charm
+ItemDisplay[MAG ID cm1 AR=36]: %GRAY%T6%MAP% %NAME%%TIER-6%
+
+// #endregion - Identified Magic Tiers
+
+//
 // RARE ITEMS
 // ==========
 // #region - Rare Items
@@ -1805,19 +2349,19 @@ ItemDisplay[FILTLVL<3 MAG umc !ID]: %NAME% // Mithril Coil (Blood Belt)
 // ------
 
 // Rare amulets with potential +2 class skills (only from Hell Baal, Diablo, and Nihlathak) (add // in the line below to remove)
-ItemDisplay[RARE !ID amu ILVL>89]: %RED%+%RED%T3%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-3%
+ItemDisplay[RARE !ID amu ILVL>89]: %RED%+T3%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-3%
 
 // TIER 4
 // ------
 
 // Rare Rings
-ItemDisplay[RARE !ID rin]: %GOLD%+%GOLD%T4%YELLOW%%MAP% %NAME%%notify-9%%TIER-4%
+ItemDisplay[RARE !ID rin]: %GOLD%T4%YELLOW%%MAP% %NAME%%notify-9%%TIER-4%
 
 // Rare Circlets
-ItemDisplay[RARE !ID CIRC]: %GOLD%+%GOLD%T4%YELLOW%%MAP% %NAME%%notify-9%%TIER-4%
+ItemDisplay[RARE !ID CIRC]: %GOLD%T4%YELLOW%%MAP% %NAME%%notify-9%%TIER-4%
 
 // Rare amulets
-ItemDisplay[RARE !ID amu]: %GOLD%+%GOLD%T4%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-4%
+ItemDisplay[RARE !ID amu]: %GOLD%T4%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-4%
 
 // TIER 5
 // ------
@@ -1826,14 +2370,14 @@ ItemDisplay[RARE !ID amu]: %GOLD%+%GOLD%T4%border-0c%%MAP-00%%dot-0c% %NAME%%not
 
 
 // Rare jewels ping only if filter level 0 or 1.
-ItemDisplay[RARE !ID jew FILTLVL<2]: %SAGE%+%SAGE%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
-ItemDisplay[RARE !ID jew FILTLVL>1]: %SAGE%+%SAGE%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-dead%%TIER-5%
+ItemDisplay[RARE !ID jew FILTLVL<2]: %SAGE%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
+ItemDisplay[RARE !ID jew FILTLVL>1]: %SAGE%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-dead%%TIER-5%
 
 // Rare Boots (not Myrmidon boots - too high str req)
-ItemDisplay[RARE !ID BOOTS !uhb]: %SAGE%+%SAGE%T5%border-0c%%Map-00%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
+ItemDisplay[RARE !ID BOOTS !uhb]: %SAGE%T5%border-0c%%Map-00%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
 
 // Rare Gloves (not Ogre Gauntlets - too high str req)
-ItemDisplay[RARE !ID GLOVES !uhg]: %SAGE%+%SAGE%T5%border-0c%%dot-00% %NAME%%notify-9%%TIER-5%
+ItemDisplay[RARE !ID GLOVES !uhg]: %SAGE%T5%border-0c%%dot-00% %NAME%%notify-9%%TIER-5%
 
 // Old Rare amulets line below, (add // on the 2 Rare amulets lines above and remove // on the line below to use)
 //ItemDisplay[RARE !ID amu]: %SAGE%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
@@ -1844,32 +2388,32 @@ ItemDisplay[RARE !ID GLOVES !uhg]: %SAGE%+%SAGE%T5%border-0c%%dot-00% %NAME%%not
 // Rare Weapons section (all tier 5, must remove // from the beginning of the ItemDisplay lines below to use)
 //=====
 // Rare assassin weapon 
-//ItemDisplay[RARE !ID (9cs OR 9lw OR 9tw OR 9qr OR 7ar OR 7wb OR 7xf OR 7cs OR 7lw OR 7tw OR 7qr)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE !ID (9cs OR 9lw OR 9tw OR 9qr OR 7ar OR 7wb OR 7xf OR 7cs OR 7lw OR 7tw OR 7qr)]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 // Rare Ethereal Berserker Axe, Colossus Sword, Colossus Blade & Crystal Sword Variants etc.
-//ItemDisplay[RARE ETH !ID (wax OR 9wa OR 7wa OR 72a OR 92a OR 2ax OR crs OR 9cr OR flb OR 9fb OR 7fb OR gsd OR 9gd OR 7gd)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE ETH !ID (wax OR 9wa OR 7wa OR 72a OR 92a OR 2ax OR crs OR 9cr OR flb OR 9fb OR 7fb OR gsd OR 9gd OR 7gd)]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 // Other eth rare axes
-//ItemDisplay[RARE ETH !ID (mpi OR 9mp OR 7mp OR axe OR 9ax OR 7ax)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
+//ItemDisplay[RARE ETH !ID (mpi OR 9mp OR 7mp OR axe OR 9ax OR 7ax)]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
 // Eth rare maces
-//ItemDisplay[RARE ETH !ID (spc OR 9sp OR 7sp OR mst OR 9mt OR 7mt OR fla OR 9fl OR 7fl OR whm OR 9wh OR 7wh)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE ETH !ID (spc OR 9sp OR 7sp OR mst OR 9mt OR 7mt OR fla OR 9fl OR 7fl OR whm OR 9wh OR 7wh)]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 // Other eth rare Swords
 //ItemDisplay[RARE ETH !ID (7ls OR 9ls OR 1sd OR 7wd OR 9wd OR wsd)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
 // Other eth rare Swords 2 handed
-//ItemDisplay[RARE ETH !ID (2hs OR 92h OR 72h OR clm OR 9cm OR 7cm OR gis OR 9gs OR 7gs OR bsw OR 9b9 OR 7b7)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
+//ItemDisplay[RARE ETH !ID (2hs OR 92h OR 72h OR clm OR 9cm OR 7cm OR gis OR 9gs OR 7gs OR bsw OR 9b9 OR 7b7)]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
 // Eth Rare Scepters
-//ItemDisplay[RARE ETH !ID WP13]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE ETH !ID WP13]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 // Rare Druid Pelts (remove // from the line below to use)
-//ItemDisplay[!ID DRU RARE]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
+//ItemDisplay[!ID DRU RARE]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 // Rare Barb Helms (remove // from the line below to use)
-//ItemDisplay[!ID BAR RARE]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
+//ItemDisplay[!ID BAR RARE]: %SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 //TIER 6
 // -----
 
 // Select Rare belts (low str req): plated (Girdle), demonhide, sharkskin, mesh, Battle, War, spiderweb, vampirefang, Mithril belts only (4 row + reasonable strength req rare belts)
-ItemDisplay[RARE !ID (hbl OR zlb OR zvb OR zmb OR ztb OR zhb OR ulc OR uvc OR umc) FILTLVL<2]: %GREEN%+%GRAY%T6%border-0c%%dot-00% %NAME%%notify-9%%TIER-6%
-ItemDisplay[RARE !ID (hbl OR zlb OR zvb OR zmb OR ztb OR zhb OR ulc OR uvc OR umc) FILTLVL>1]: %GREEN%+%GRAY%T6 %NAME%%notify-dead%%TIER-6%
+ItemDisplay[RARE !ID (hbl OR zlb OR zvb OR zmb OR ztb OR zhb OR ulc OR uvc OR umc) FILTLVL<2]: %GRAY%T6%border-0c%%dot-00% %NAME%%notify-9%%TIER-6%
+ItemDisplay[RARE !ID (hbl OR zlb OR zvb OR zmb OR ztb OR zhb OR ulc OR uvc OR umc) FILTLVL>1]: %GRAY%T6 %NAME%%notify-dead%%TIER-6%
 
 // Whitelist only
 // --------------
@@ -3601,7 +4145,7 @@ ItemDisplay[INF ARMOR]: {%WHITE%Upgrade to normal quality (ilvl 1) with %ORANGE%
 // -----------------------------
 
 // grand charms with potential 45 life
-ItemDisplay[MAG ID cm3 ILVL>90]: {%WHITE%Reroll with 3 Perfect Gems}
+ItemDisplay[MAG ID cm3 ILVL>90]: {%WHITE%Reroll with 3 Perfect Gems %NL%%WHITE%Baal/Diablo/Nih Grand Charm}
 
 // Slash supporter Small Charm (slash specific)
 ItemDisplay[MAG cm1 FRW=3 LIFE=20]: {%WHITE%BH menu to prevent Invalid Stat Error %NL%Use the Suppress Invalid Stats option in}

--- a/BH.cfg
+++ b/BH.cfg
@@ -1,7 +1,8 @@
-// Slash Diablo Maphack Configuration, v2.7.1
+// Slash Diablo Maphack Configuration, v2.7.2
 // Authors: M81, BeLikeLeBron, Dax, Labarr, Lewds, DannyIsGreat
 // Requires BH>=1.9.9 (planqi branch)
 // Note: 1.9.9-b10 no longer supported. Must have the full Planqi 1.9.9 BH.dll release OR danny's beta bh 1.9.9
+// #region - Info
 
 // Link to Download the latest config: https://github.com/BeLikeLeBron/bhconfig/releases/latest
 // Link to user guide: https://github.com/BeLikeLeBron/bhconfig/wiki/User-Guide
@@ -93,10 +94,11 @@
 //12 = Slightly less darker green
 //13 = White
 //%notify-dead% = no notification
-
+// #endregion - Info
 //
 // GEMS
 // ====
+// #region - Gems
 
 // Indicators: Colour coded (eg. Purple for Amethysts)
 ItemDisplay[GEMTYPE=1 GEMLEVEL>3]: %PURPLE%O%WHITE%%GEMLEVEL%%CONTINUE%
@@ -167,10 +169,12 @@ ItemDisplay[GEMLEVEL=4 (GEMTYPE=6)]: %NAME%%dot-0c%%notify-dead%
 ItemDisplay[GEMLEVEL=4 (GEMTYPE=7)]: %NAME%%dot-d6%%notify-dead%
 
 ItemDisplay[GEMTYPE>0 GEMLEVEL>3]: %NAME% // Whitelist all flawless and perfect gems
+// #endregion - Gems
 
 //
 // RUNES
 // =====
+// #region - Runes
 
 // Set color
 ItemDisplay[RUNE>0]: %ORANGE%%NAME%%CONTINUE%
@@ -231,11 +235,12 @@ ItemDisplay[RUNE=3 OR RUNE=8 OR RUNE=7 OR RUNE=12]: %WHITE%+ %NAME%
 
 ItemDisplay[RUNE>0]: %NAME% // whitelist all runes
 
-
+// #endregion - Runes
 
 //
 // SHOPPING
 // ========
+// #region - Shopping
 
 // This must be done before the recoloring below.
 // Best place to shop in [square brackets]. Make sure to check the required affix level. The affix
@@ -367,7 +372,7 @@ ItemDisplay[(zvb OR uvc) !ETH MAG !ID CLVL<80 FILTLVL<2]: %GREEN%+%GRAY%T6T6%bor
 ItemDisplay[NMAG (zlb OR zvb) CLVL<41 FILTLVL<2]: %GRAY%T6%MAP% %WHITE%%NAME%%TIER-6%
 ItemDisplay[MAG ID (zlb OR zvb) CLVL<41 FILTLVL<2]: %GRAY%T6%MAP% %GREEN%*****%PURPLE%%NAME%%GREEN%*****%TIER-6%
 ItemDisplay[MAG !ID (zlb OR zvb) CLVL<50 FILTLVL<2]: %GRAY%T6%BLUE%%MAP% %NAME%%TIER-6%
-ItemDisplay[RARE (zlb OR zvb) CLVL<60 FILTLVL<2]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[RARE (zlb OR zvb) CLVL<60 FILTLVL<2]: %GREEN%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 // Tele staff (SK=54, lvl=1-6, formula SK*64+lvl)
 // of Teleportation, alvl 24
@@ -492,11 +497,12 @@ ItemDisplay[MAG HELM FHR>9 (CRES>20 OR FRES>20 OR LRES>20 OR SOCK=2) ALVL<33]: %
 // Artisan's, alvl 33 (also need ilvl 41+ base)
 ItemDisplay[MAG HELM !BAR SOCK=3 ALVL<68]: %GRAY%T6%MAP% %GREEN%*****%PURPLE%%NAME%%GREEN%*****%TIER-6%
 
-
+// #endregion - Shopping
 
 //
 // ADD METADATA
 // ============
+// #region - Metadata
 
 // Set the colors of items manually so that we can prepend colored tags easily
 ItemDisplay[UNI]: %GOLD%%NAME%%CONTINUE%
@@ -524,7 +530,7 @@ ItemDisplay[!RW NMAG (NORM OR EXC OR ELT) PRICE>34999 DIFF=2]: %NAME% %GRAY%$%CO
 //ItemDisplay[WEAPON !CL6 !WP12]: [+%RANGE% %WPNSPD%] %NAME% %CONTINUE%
 
 // Display ilvl and price (remove // on the line below to use)
-//ItemDisplay[!RUNE>0 !GEM>0]: %NAME% [L%ILVL%] (%PRICE%)%CONTINUE%
+//ItemDisplay[!RUNE>0 !GEM>0]: %NAME% %GRAY%[L%ILVL%] (%PRICE%)%CONTINUE%
 
 
 // Set the trailing color so that the sell price in vendor screens looks vanilla
@@ -540,10 +546,13 @@ ItemDisplay[CRAFT]: %NAME%%ORANGE%%CONTINUE% // need 1.9.8
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
+// #endregion - Metadata
 
 //
 // UNIQUES AND SETS
 // ================
+// #region - Uniques and Sets
+//
 //
 // ADD HOLY GRAIL ITEMS HERE
 // =========================
@@ -923,6 +932,8 @@ ItemDisplay[UNI xap]: %GRAY%T6%MAP% %NAME%%TIER-6%
 ItemDisplay[UNI xtp]: %GRAY%T6%MAP% %NAME%%TIER-6%
 // Gerke's Sanctuary (shield)
 ItemDisplay[UNI xow]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Buriza-Do Kyanon Ballista (Crossbow)
+ItemDisplay[UNI 8hx]: %GRAY%T6%MAP% %NAME%%TIER-6%
 
 //Potential Angelic's set rings only if filter = 0
 ItemDisplay[SET rin FILTLVL=0]: %GRAY%T6%MAP% %NAME%%TIER-6%
@@ -938,6 +949,8 @@ ItemDisplay[SET mbt FILTLVL=0]: %GRAY%T6%MAP% %NAME%%TIER-6%
 ItemDisplay[UNI gts FILTLVL=0]: %GRAY%T6%MAP% %NAME%%TIER-6%
 // Wall of the Eyeless (Bone Shield) only if filter = 0
 ItemDisplay[UNI bsh FILTLVL=0]: %GRAY%T6%MAP% %NAME%%TIER-6%
+// Skin of the Flayed One (Demonhide Armor) only if filter = 0
+ItemDisplay[UNI xla FILTLVL=0]: %GRAY%T6%MAP% %NAME%%TIER-6%
 
 //
 // UNIDENTIFIED UNIQUES/SETS
@@ -977,11 +990,12 @@ ItemDisplay[UNI cm2 !ID]: %RED%+%GOLD%T3%MAP% %NAME%%TIER-3%
 
 ItemDisplay[UNI OR SET]: %NAME%
 
+// #endregion - Uniques and Sets
 
 //
 // SOCKETABLES
 // ===========
-
+// #region - Socketables
 
 // TIER 1
 // ------
@@ -1666,42 +1680,45 @@ ItemDisplay[FILTLVL<3 NMAG !RW uvg]: %NAME% // Vampirebone Gloves (Imbue)
 ItemDisplay[FILTLVL<3 NMAG !RW ulb]: %NAME% // Wyrmhide Boots (Imbue)
 ItemDisplay[FILTLVL<3 NMAG !RW ulc]: %NAME% // Spiderweb Sash (Imbue)
 
+// #endregion - Socketables
+
 //
 // MAGIC ITEMS
 // ===========
+// #region - Magic Items
 
 // TIER 3
 // ------
 
 // grand charms with potential 45 life (only from Hell Baal, Diablo, and Nihlathak) (add // on the line below to remove)
-ItemDisplay[!ID MAG cm3 ILVL>90]: %RED%+%BLUE%T3%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
+ItemDisplay[!ID MAG cm3 ILVL>90]: %RED%+T3%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
 
 // grand charms with potential 45 life marked with a red + for rerolling (identified) (add // on the line below to remove)
-ItemDisplay[ID MAG cm3 ILVL>90]: %RED%+%BLUE%%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
+ItemDisplay[ID MAG cm3 ILVL>90]: %RED%+T3%BLUE%%border-97%%dot-1f% %NAME%%notify-3%%TIER-3%
 
 // TIER 4
 // ------
 
 // Circlet Variants (many good things)
-ItemDisplay[CIRC !ETH MAG !ID]: %GREEN%+%BLUE%T4%MAP% %NAME%%notify-3%%TIER-4%
+ItemDisplay[CIRC !ETH MAG !ID]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%notify-3%%TIER-4%
 
 //Old line for jewels small and grand charms (remove // on the line below AND add // on the gc/jewels/sc lines below to use)
-//ItemDisplay[!ID MAG (cm1 OR cm3 OR jew)]: %GREEN%+%BLUE%T4%MAP% %NAME%%notify-3%%TIER-4%
+//ItemDisplay[!ID MAG (cm1 OR cm3 OR jew)]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%notify-3%%TIER-4%
 
 // grand charms
-ItemDisplay[!ID MAG cm3]: %GREEN%+%BLUE%T4%border-97%%dot-1f% %NAME%%notify-3%%TIER-4%
+ItemDisplay[!ID MAG cm3]: %GOLD%+%GOLD%T4%border-97%%dot-1f% %NAME%%notify-3%%TIER-4%
 
 // Small charms
-ItemDisplay[!ID MAG cm1]: %GREEN%+%BLUE%T4%border-97%%dot-84%%px-97% %NAME%%notify-3%%TIER-4% 
+ItemDisplay[!ID MAG cm1]: %GOLD%+%GOLD%T4%border-97%%dot-84%%px-97% %NAME%%notify-3%%TIER-4% 
 
 // Large charms with notifications on tier 4 (remove // on the line below to use)
-//ItemDisplay[!ID MAG cm2]: %WHITE%+%BLUE%T6%border-97%%dot-00% %NAME%%notify-3%%TIER-4%
+//ItemDisplay[!ID MAG cm2]: %WHITE%+%GRAY%T6%border-97%%dot-00% %NAME%%notify-3%%TIER-4%
 
 //jewels
-ItemDisplay[!ID MAG jew]: %GREEN%+%BLUE%T4%Map-97%%dot-97%%px-00% %NAME%%notify-3%%TIER-4%
+ItemDisplay[!ID MAG jew]: %GOLD%+%GOLD%T4%Map-97%%dot-97%%px-00% %NAME%%notify-3%%TIER-4%
 
 // Monarchs (for JMoD)
-ItemDisplay[uit !ETH MAG !ID]: %GREEN%+%BLUE%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[uit !ETH MAG !ID]: %GOLD%+%GOLD%T4%BLUE%%MAP% %NAME%%TIER-4%
 
 
 // TIER 5
@@ -1777,28 +1794,30 @@ ItemDisplay[FILTLVL<3 MAG ulb !ID]: %NAME% // Wyrmhide Boots (Caster Boots)
 ItemDisplay[FILTLVL<3 MAG uvc !ID]: %NAME% // Vampirefang Belt (Caster Belt)
 ItemDisplay[FILTLVL<3 MAG umc !ID]: %NAME% // Mithril Coil (Blood Belt)
 
+// #endregion - Magic Items
 
 //
 // RARE ITEMS
 // ==========
+// #region - Rare Items
 
 // TIER 3
 // ------
 
 // Rare amulets with potential +2 class skills (only from Hell Baal, Diablo, and Nihlathak) (add // in the line below to remove)
-ItemDisplay[RARE !ID amu ILVL>89]: %GREEN%+%RED%T3%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-3%
+ItemDisplay[RARE !ID amu ILVL>89]: %RED%+%RED%T3%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-3%
 
 // TIER 4
 // ------
 
 // Rare Rings
-ItemDisplay[RARE !ID rin]: %GREEN%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
+ItemDisplay[RARE !ID rin]: %GOLD%+%GOLD%T4%YELLOW%%MAP% %NAME%%notify-9%%TIER-4%
 
 // Rare Circlets
-ItemDisplay[RARE !ID CIRC]: %GREEN%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
+ItemDisplay[RARE !ID CIRC]: %GOLD%+%GOLD%T4%YELLOW%%MAP% %NAME%%notify-9%%TIER-4%
 
 // Rare amulets
-ItemDisplay[RARE !ID amu]: %GREEN%+%YELLOW%T4%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-4%
+ItemDisplay[RARE !ID amu]: %GOLD%+%GOLD%T4%border-0c%%MAP-00%%dot-0c% %NAME%%notify-9%%TIER-4%
 
 // TIER 5
 // ------
@@ -1807,43 +1826,43 @@ ItemDisplay[RARE !ID amu]: %GREEN%+%YELLOW%T4%border-0c%%MAP-00%%dot-0c% %NAME%%
 
 
 // Rare jewels ping only if filter level 0 or 1.
-ItemDisplay[RARE !ID jew FILTLVL<2]: %GREEN%+%YELLOW%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
-ItemDisplay[RARE !ID jew FILTLVL>1]: %GREEN%+%YELLOW%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-dead%%TIER-5%
+ItemDisplay[RARE !ID jew FILTLVL<2]: %SAGE%+%SAGE%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
+ItemDisplay[RARE !ID jew FILTLVL>1]: %SAGE%+%SAGE%T5%Map-0c%%dot-0c%%px-00% %NAME%%notify-dead%%TIER-5%
 
 // Rare Boots (not Myrmidon boots - too high str req)
-ItemDisplay[RARE !ID BOOTS !uhb]: %GREEN%+%YELLOW%T5%border-0c%%Map-00%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
+ItemDisplay[RARE !ID BOOTS !uhb]: %SAGE%+%SAGE%T5%border-0c%%Map-00%%dot-0c%%px-00% %NAME%%notify-9%%TIER-5%
 
 // Rare Gloves (not Ogre Gauntlets - too high str req)
-ItemDisplay[RARE !ID GLOVES !uhg]: %GREEN%+%YELLOW%T5%border-0c%%dot-00% %NAME%%notify-9%%TIER-5%
+ItemDisplay[RARE !ID GLOVES !uhg]: %SAGE%+%SAGE%T5%border-0c%%dot-00% %NAME%%notify-9%%TIER-5%
 
 // Old Rare amulets line below, (add // on the 2 Rare amulets lines above and remove // on the line below to use)
-//ItemDisplay[RARE !ID amu]: %GREEN%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
+//ItemDisplay[RARE !ID amu]: %SAGE%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
 
 // Old Rare jewels line below, (add // on the 2 Rare jewels lines above and remove // on the line below to use)
-//ItemDisplay[RARE !ID jew]: %GREEN%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
+//ItemDisplay[RARE !ID jew]: %SAGE%+%YELLOW%T4%MAP% %NAME%%notify-9%%TIER-4%
 
 // Rare Weapons section (all tier 5, must remove // from the beginning of the ItemDisplay lines below to use)
 //=====
 // Rare assassin weapon 
-//ItemDisplay[RARE !ID (9cs OR 9lw OR 9tw OR 9qr OR 7ar OR 7wb OR 7xf OR 7cs OR 7lw OR 7tw OR 7qr)]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE !ID (9cs OR 9lw OR 9tw OR 9qr OR 7ar OR 7wb OR 7xf OR 7cs OR 7lw OR 7tw OR 7qr)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 // Rare Ethereal Berserker Axe, Colossus Sword, Colossus Blade & Crystal Sword Variants etc.
-//ItemDisplay[RARE ETH !ID (wax OR 9wa OR 7wa OR 72a OR 92a OR 2ax OR crs OR 9cr OR flb OR 9fb OR 7fb OR gsd OR 9gd OR 7gd)]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE ETH !ID (wax OR 9wa OR 7wa OR 72a OR 92a OR 2ax OR crs OR 9cr OR flb OR 9fb OR 7fb OR gsd OR 9gd OR 7gd)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 // Other eth rare axes
-//ItemDisplay[RARE ETH !ID (mpi OR 9mp OR 7mp OR axe OR 9ax OR 7ax)]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5% 
+//ItemDisplay[RARE ETH !ID (mpi OR 9mp OR 7mp OR axe OR 9ax OR 7ax)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
 // Eth rare maces
-//ItemDisplay[RARE ETH !ID (spc OR 9sp OR 7sp OR mst OR 9mt OR 7mt OR fla OR 9fl OR 7fl OR whm OR 9wh OR 7wh)]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE ETH !ID (spc OR 9sp OR 7sp OR mst OR 9mt OR 7mt OR fla OR 9fl OR 7fl OR whm OR 9wh OR 7wh)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 // Other eth rare Swords
-//ItemDisplay[RARE ETH !ID (7ls OR 9ls OR 1sd OR 7wd OR 9wd OR wsd)]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5% 
+//ItemDisplay[RARE ETH !ID (7ls OR 9ls OR 1sd OR 7wd OR 9wd OR wsd)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
 // Other eth rare Swords 2 handed
-//ItemDisplay[RARE ETH !ID (2hs OR 92h OR 72h OR clm OR 9cm OR 7cm OR gis OR 9gs OR 7gs OR bsw OR 9b9 OR 7b7)]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5% 
+//ItemDisplay[RARE ETH !ID (2hs OR 92h OR 72h OR clm OR 9cm OR 7cm OR gis OR 9gs OR 7gs OR bsw OR 9b9 OR 7b7)]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5% 
 // Eth Rare Scepters
-//ItemDisplay[RARE ETH !ID WP13]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+//ItemDisplay[RARE ETH !ID WP13]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 // Rare Druid Pelts (remove // from the line below to use)
-//ItemDisplay[!ID DRU RARE]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+//ItemDisplay[!ID DRU RARE]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 // Rare Barb Helms (remove // from the line below to use)
-//ItemDisplay[!ID BAR RARE]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+//ItemDisplay[!ID BAR RARE]: %SAGE%+%SAGE%T5%YELLOW%%MAP% %NAME%%TIER-5%
 
 //TIER 6
 // -----
@@ -1897,8 +1916,11 @@ ItemDisplay[SCEPTER RARE !ID]: %NAME%
 // Eth rares
 ItemDisplay[RARE ETH !ID]: %NAME%
 
+// #endregion - Rare Items
+
 // RENAME
 // ======
+// #region - Misc
 
 // Rename misc items (potions, scrolls, etc.)
 // This is not the filter section. To filter these items, CTRL+F for code to locate in FILTER section, then uncomment the line.
@@ -1928,6 +1950,7 @@ ItemDisplay[mp5]: %BLUE%+ %WHITE%M5%CONTINUE%
 ItemDisplay[key]: %DARK_GREEN%+ %WHITE%KEY%CONTINUE%
 
 //Rejuv potions (To rename change "R1" and "R2" in the 2 lines below to "Rejuv" and "Full Rejuv" respectively)
+//If you want Notifications and map boxes for rejuvs/full rejuvs, add %MAP-91% before %CONTINUE% on the two lines below
 ItemDisplay[rvs]: %PURPLE%+ %PURPLE%R1%CONTINUE%
 ItemDisplay[rvl]: %PURPLE%+ %PURPLE%R2 +%CONTINUE%
 
@@ -1976,12 +1999,13 @@ ItemDisplay[!RUNE>0 !GEM>0 DIFF=0 CLVL>1 CLVL<15 PRICE>999 FILTLVL=0]: %NAME%%GR
 //show price if worth 400+ gold if char level under 5 and filter level 0
 ItemDisplay[!RUNE>0 !GEM>0 DIFF=0 CLVL>1 CLVL<5 PRICE>399 FILTLVL=0]: %NAME%%GRAY% $%PRICE%
 
-
+// #endregion - Misc
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // ITEM FILTER
 // ===========
+// #region - Filter
 
 // Below: Uncomment to hide.
 // Items will be hidden if:
@@ -3216,8 +3240,10 @@ ItemDisplay[FILTLVL=2 RARE !ETH !ID 8rx]: // Chu-Ko-Nu
 
 
 
-// MISC
+// MISC 
 //
+ItemDisplay[FILTLVL>0 aqv]: // Arrows (Add // at the beginning of this line to show)
+ItemDisplay[FILTLVL>0 cqv]: // Bolts
 //ItemDisplay[FILTLVL>0 elx]: // elixir
 //ItemDisplay[FILTLVL>0 tbk]: // Town Portal Book
 //ItemDisplay[FILTLVL>0 ibk]: // Identify Book
@@ -3227,9 +3253,7 @@ ItemDisplay[FILTLVL=2 RARE !ETH !ID 8rx]: // Chu-Ko-Nu
 //ItemDisplay[FILTLVL>0 gld]: // gold
 //ItemDisplay[FILTLVL>0 bks]: // Bark Scroll
 //ItemDisplay[FILTLVL>0 bkd]: // deciphered Bark Scroll
-ItemDisplay[FILTLVL>0 aqv]: // Arrows
 //ItemDisplay[FILTLVL>0 tch]: // Torch
-ItemDisplay[FILTLVL>0 cqv]: // Bolts
 //ItemDisplay[FILTLVL>0 tsc]: // Town Portal Scroll
 //ItemDisplay[FILTLVL>0 isc]: // Identify Scroll
 //ItemDisplay[FILTLVL>0 hrt]: // Not used
@@ -3320,10 +3344,12 @@ ItemDisplay[FILTLVL>0 cqv]: // Bolts
 //ItemDisplay[FILTLVL>0 toa]: // Token of Absolution
 //ItemDisplay[FILTLVL>0 std]: // Standard of Heroes
 
+// #endregion - Filter
 
 //
 // ITEM DESCRIPTIONS
 // =================
+// #region - Item Descriptions
 
 // Runewords
 // ---------
@@ -3583,3 +3609,5 @@ ItemDisplay[MAG cm1 FRW=3 LIFE=20]: {%WHITE%BH menu to prevent Invalid Stat Erro
 // Other slash stuff
 //Herb for uber diablo anni (slash specific)
 ItemDisplay[hrb]: {%WHITE%To Spawn %GOLD%Uber Diablo %WHITE%for %GOLD%Anni %NL% %WHITE%Sell to a vendor in a %RED%Hell %WHITE%game}
+
+// #endregion - Item Descriptions

--- a/BH_settings.cfg
+++ b/BH_settings.cfg
@@ -1,4 +1,4 @@
-// Slash Diablo Default BH_settings, v2.7.1 requires Danny's Bh.dll (1.9.9 with beta features) 
+// Slash Diablo Default BH_settings, v2.7.2 requires Danny's Bh.dll (1.9.9 with beta features) 
 // Authors: M81, Labarr, DannyIsGreat, BeLikeLeBron, Lewds
 // Requires BH>=1.9.9 (DannyIsGreat's dschu BETA)
 // This file will be customized by the user. It's meant to be a template. The item
@@ -213,12 +213,12 @@ Party Enabled:          True, None
 Looting Enabled:        True, None
 
 //Using Potions in Inventory [CUSTOM]
-// Use Healing Potion:     False, VK_V
-// Use Mana Potion:        False, VK_G
-// Use Rejuv Potion:       VK_NUMPADDIVIDE
+Use Healing Potion:     False, VK_V
+Use Mana Potion:        False, VK_G
+Use Rejuv Potion:       VK_NUMPADDIVIDE
 
-// Use TP from tome in inventory [CUSTOM]
-// Use TP Tome: VK_Z
+// Use TP from tome in inventory [CUSTOM] (Add // to the beginning of the line below to remove)
+Use TP Tome: VK_Z
 
 //Item Display Configuration
 Advanced Item Display:  True, None


### PR DESCRIPTION
Id’d Magic’s tiers added
Whitelist runewords and add %MAP% in metadata area
magics tiers consistent now with others
rares tiers consistent now with others
mag amulets crafting dot and grand charm dot for nih/baal id'd/unid'd gc's dot pushed to back
Color consistency on Tier labels for magics/rares
Support for regions for VSCODE (collapsible sections)
//buriza ballista
//t6 skin of the flayed one demonhide armor
make juv/pot lines easier to edit instructions