### PR TITLE
Remove socket recipe description from inferior quality items

### DIFF
--- a/BH.cfg
+++ b/BH.cfg
@@ -7394,13 +7394,13 @@ ItemDisplay[!CLASSIC NMAG !RW WEAPON ETH ELT SOCK=6]: {%WHITE%Breath of the Dyin
 // -----------
 
 // Armor socket recipe
-ItemDisplay[!CLASSIC NMAG !RW CHEST !SUP SOCK=0]: {%WHITE%Add sockets with %ORANGE%Tal Thul %YELLOW%O%WHITE%Perfect}
+ItemDisplay[!CLASSIC NMAG !RW CHEST !SUP !INF SOCK=0]: {%WHITE%Add sockets with %ORANGE%Tal Thul %YELLOW%O%WHITE%Perfect}
 // Weapon socket recipe
-ItemDisplay[!CLASSIC NMAG !RW WEAPON !THROWING !SUP SOCK=0]: {%WHITE%Add sockets with %ORANGE%Ral Amn %PURPLE%O%WHITE%Perfect}
+ItemDisplay[!CLASSIC NMAG !RW WEAPON !THROWING !SUP !INF SOCK=0]: {%WHITE%Add sockets with %ORANGE%Ral Amn %PURPLE%O%WHITE%Perfect}
 // Shield socket recipe
-ItemDisplay[!CLASSIC NMAG !RW SHIELD !SUP SOCK=0]: {%WHITE%Add sockets with %ORANGE%Tal Amn %RED%O%WHITE%Perfect}
+ItemDisplay[!CLASSIC NMAG !RW SHIELD !SUP !INF SOCK=0]: {%WHITE%Add sockets with %ORANGE%Tal Amn %RED%O%WHITE%Perfect}
 // Helm socket recipe
-ItemDisplay[!CLASSIC NMAG !RW HELM !SUP SOCK=0]: {%WHITE%Add sockets with %ORANGE%Ral Thul %BLUE%O%WHITE%Perfect}
+ItemDisplay[!CLASSIC NMAG !RW HELM !SUP !INF SOCK=0]: {%WHITE%Add sockets with %ORANGE%Ral Thul %BLUE%O%WHITE%Perfect}
 
 
 // Rune Descriptions


### PR DESCRIPTION
Inferior (INF) quality items such as cracked, low quality, and damaged items cannot have sockets added to them via the cube recipe and shouldn't have the help text show up in their description